### PR TITLE
Codemod flatten iife global assignment

### DIFF
--- a/test/fixtures/flatten-iife-global-assignment/basic.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/basic.input.js
@@ -1,0 +1,5 @@
+App.A = (function() {
+  function A() {}
+
+  return A;
+})();

--- a/test/fixtures/flatten-iife-global-assignment/basic.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/basic.output.js
@@ -1,0 +1,1 @@
+App.A = function A() {};

--- a/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.input.js
@@ -1,0 +1,9 @@
+App.A = (function() {
+  function Q() {}
+
+  Q.prototype.foo = function() {
+    return 'bar';
+  };
+
+  return Q;
+})();

--- a/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.input.js
@@ -5,5 +5,9 @@ App.A = (function() {
     return 'bar';
   };
 
+  function buzz() {
+    return new Q();
+  }
+
   return Q;
 })();

--- a/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.output.js
@@ -1,0 +1,5 @@
+App.A = function A() {};
+
+App.A.prototype.foo = function() {
+  return 'bar';
+};

--- a/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/inconsistent-naming.output.js
@@ -3,3 +3,7 @@ App.A = function A() {};
 App.A.prototype.foo = function() {
   return 'bar';
 };
+
+function buzz() {
+  return new App.A();
+}

--- a/test/fixtures/flatten-iife-global-assignment/no-return.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/no-return.input.js
@@ -1,0 +1,3 @@
+App.A = (function() {
+  function A() {}
+})();

--- a/test/fixtures/flatten-iife-global-assignment/no-return.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/no-return.output.js
@@ -1,0 +1,3 @@
+App.A = (function() {
+  function A() {}
+})();

--- a/test/fixtures/flatten-iife-global-assignment/non-members.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/non-members.input.js
@@ -1,0 +1,15 @@
+App.A = (function() {
+  var Buzz = Fizz.Buzz;
+
+  function A() {}
+
+  A.prototype.foo = function() {
+    return buzz('bar');
+  };
+
+  function buzz(str) {
+    return new Buzz(`${str} buzzzzzzzzzzzz`);
+  }
+
+  return A;
+})();

--- a/test/fixtures/flatten-iife-global-assignment/non-members.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/non-members.output.js
@@ -1,0 +1,11 @@
+var Buzz = Fizz.Buzz;
+
+App.A = function A() {};
+
+App.A.prototype.foo = function() {
+  return buzz('bar');
+};
+
+function buzz(str) {
+  return new Buzz(`${str} buzzzzzzzzzzzz`);
+}

--- a/test/fixtures/flatten-iife-global-assignment/prototype-methods.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/prototype-methods.input.js
@@ -1,0 +1,9 @@
+App.A = (function() {
+  function A() {}
+
+  A.prototype.foo = function() {
+    return 'bar';
+  };
+
+  return A;
+})();

--- a/test/fixtures/flatten-iife-global-assignment/prototype-methods.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/prototype-methods.output.js
@@ -1,0 +1,5 @@
+App.A = function A() {};
+
+App.A.prototype.foo = function() {
+  return 'bar';
+};

--- a/test/fixtures/flatten-iife-global-assignment/statement-after-return.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/statement-after-return.input.js
@@ -1,0 +1,7 @@
+App.A = (function() {
+  function A() {}
+
+  return A;
+
+  function b() {}
+})();

--- a/test/fixtures/flatten-iife-global-assignment/statement-after-return.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/statement-after-return.output.js
@@ -1,0 +1,7 @@
+App.A = (function() {
+  function A() {}
+
+  return A;
+
+  function b() {}
+})();

--- a/test/fixtures/flatten-iife-global-assignment/static-methods.input.js
+++ b/test/fixtures/flatten-iife-global-assignment/static-methods.input.js
@@ -1,0 +1,9 @@
+App.A = (function() {
+  function A() {}
+
+  A.foo = function() {
+    return 'bar';
+  };
+
+  return A;
+})();

--- a/test/fixtures/flatten-iife-global-assignment/static-methods.output.js
+++ b/test/fixtures/flatten-iife-global-assignment/static-methods.output.js
@@ -1,0 +1,5 @@
+App.A = function A() {};
+
+App.A.foo = function() {
+  return 'bar';
+};

--- a/test/transforms/flatten-iife-global-assignment.test.js
+++ b/test/transforms/flatten-iife-global-assignment.test.js
@@ -1,0 +1,34 @@
+import 'test-helper';
+import flattenIifeGlobalAssignment from 'flatten-iife-global-assignment';
+
+describe('flattenIifeGlobalAssignment', () => {
+  it('flattens IIFE assignments', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/basic', {
+      globalIdentifiers: ['App'],
+    });
+  });
+
+  it('assigns prototype methods', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/prototype-methods', {
+      globalIdentifiers: ['App'],
+    });
+  });
+
+  it('assigns static methods', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/static-methods', {
+      globalIdentifiers: ['App'],
+    });
+  });
+
+  it('includes non members', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/non-members', {
+      globalIdentifiers: ['App'],
+    });
+  });
+
+  it('does not break for identifier mismatch', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/inconsistent-naming', {
+      globalIdentifiers: ['App'],
+    });
+  });
+});

--- a/test/transforms/flatten-iife-global-assignment.test.js
+++ b/test/transforms/flatten-iife-global-assignment.test.js
@@ -31,4 +31,16 @@ describe('flattenIifeGlobalAssignment', () => {
       globalIdentifiers: ['App'],
     });
   });
+
+  it('does not do anything if there is no return', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/no-return', {
+      globalIdentifiers: ['App'],
+    });
+  });
+
+  it('does not do anything if the last statement is not a return', () => {
+    expect(flattenIifeGlobalAssignment).to.transform('flatten-iife-global-assignment/statement-after-return', {
+      globalIdentifiers: ['App'],
+    });
+  });
 });

--- a/transforms/flatten-iife-global-assignment.js
+++ b/transforms/flatten-iife-global-assignment.js
@@ -23,7 +23,7 @@ export default function flattenIifeGlobalAssignment(
     );
   }
 
-  function createIifeReturnAssignment(member, node) {
+  function createGlobalIdentiferAssignment(member, node) {
     return j.expressionStatement(
       j.assignmentExpression(
         '=',
@@ -33,17 +33,17 @@ export default function flattenIifeGlobalAssignment(
     );
   }
 
-  function createIifeReturnMemberAssignment(member, node) {
+  function createGlobalIdentifierAssignmentMember(member, node) {
     return j.expressionStatement(
       j.assignmentExpression(
         node.expression.operator,
-        formatReturnAssignmentMemberExpression(node.expression.left, member),
+        prependToMemberExpression(node.expression.left, member),
         node.expression.right,
       ),
     );
   }
 
-  function formatReturnAssignmentMemberExpression(memberExpression, prependee) {
+  function prependToMemberExpression(memberExpression, prependee) {
     const identifiers = [];
     let currentNode = memberExpression;
 
@@ -89,9 +89,9 @@ export default function flattenIifeGlobalAssignment(
 
       return functionBlock.body.map((node) => {
         if (nodeIsReturned(returnIdentifier, node)) {
-          return createIifeReturnAssignment(member, node);
+          return createGlobalIdentiferAssignment(member, node);
         } else if (nodeIsAssignedToReturn(returnIdentifier, node)) {
-          return createIifeReturnMemberAssignment(member, node);
+          return createGlobalIdentifierAssignmentMember(member, node);
         }
         return node;
       });

--- a/transforms/flatten-iife-global-assignment.js
+++ b/transforms/flatten-iife-global-assignment.js
@@ -1,0 +1,113 @@
+import {findFirstMember, getBlockStatementFromFunction} from './utils';
+
+export default function flattenIifeGlobalAssignment(
+  {source},
+  {jscodeshift: j},
+  {printOptions = {}, appGlobalIdentifiers},
+) {
+  const root = j(source);
+
+  function findAssignments() {
+    return root
+      .find(j.ExpressionStatement, {
+        expression: {
+          type: 'AssignmentExpression',
+          operator: '=',
+          left: {
+            type: 'MemberExpression',
+            object: (object) =>
+              appGlobalIdentifiers.indexOf(findFirstMember(object).name) >= 0,
+          },
+          right: {
+            type: 'CallExpression',
+            callee: {
+              type: 'FunctionExpression',
+            },
+          },
+        },
+      });
+  }
+
+  function nodeIsReturned(returnIdentifier, node) {
+    return node.type === 'FunctionDeclaration' && node.id.name === returnIdentifier;
+  }
+
+  function nodeIsAssignedToReturn(returnIdentifier, node) {
+    return (
+      returnIdentifier &&
+      node.type === 'ExpressionStatement' &&
+      findFirstMember(node.expression.left).name === returnIdentifier
+    );
+  }
+
+  function createIifeReturnAssignment(member, node) {
+    return j.expressionStatement(
+      j.assignmentExpression(
+        '=',
+        member,
+        j.functionExpression(member.property, node.params, node.body),
+      ),
+    );
+  }
+
+  function createIifeReturnMemberAssignment(member, node) {
+    return j.expressionStatement(
+      j.assignmentExpression(
+        node.expression.operator,
+        formatReturnAssignmentMemberExpression(node.expression.left, member),
+        node.expression.right,
+      ),
+    );
+  }
+
+  function formatReturnAssignmentMemberExpression(memberExpression, prependee) {
+    const identifiers = [];
+    let currentNode = memberExpression;
+
+    // Take all but the last, which is copied from the base memberExpression
+    while (currentNode.type === 'MemberExpression') {
+      identifiers.push(currentNode.property);
+      currentNode = currentNode.object;
+    }
+
+    let newExpression = prependee;
+
+    while (identifiers.length) {
+      newExpression = j.memberExpression(newExpression, identifiers.pop());
+    }
+
+    return newExpression;
+  }
+
+  function flattenAssignment(path) {
+    const {left: member, right: statement} = path.node.expression;
+    const functionBlock = getBlockStatementFromFunction(statement.callee);
+
+    let returnIdentifier;
+
+    function liftNode(result, node) {
+      if (node.type === 'ReturnStatement') {
+        returnIdentifier = node.argument.name;
+        return result;
+      }
+
+      if (!returnIdentifier) {
+        result.push(node);
+      } else if (nodeIsReturned(returnIdentifier, node)) {
+        result.push(createIifeReturnAssignment(member, node));
+      } else if (nodeIsAssignedToReturn(returnIdentifier, node)) {
+        result.push(createIifeReturnMemberAssignment(member, node));
+      } else {
+        result.push(node);
+      }
+
+      return result;
+    }
+
+    return functionBlock.body.reverse().reduce(liftNode, []).reverse();
+  }
+
+  return findAssignments()
+    .replaceWith(flattenAssignment)
+    .toSource(printOptions);
+}


### PR DESCRIPTION
(Originally submitted by @nathanmarks to the old `Shopify/javascript` repo.)

Let me know if you have a better idea for a name... 

This was created for preparing files in `marketing_assets` for some of the other transforms we have such as `global-assign-to-default-export`, etc...

It takes in your `appGlobalIdentifiers` (such as `ShopifyMarketing`) and lifts the code from inside the IIFE to the module root. It looks at the `return` statement inside the IIFE and assigns that + members of the returned object to the global identifier.

If the naming of the return identifier is inconsistent, it uses the property identifier found on the global object rather than the return identifier used inside the IIFE.

Every module in `marketing_assets` and other marketing properties are written using this pattern: https://github.com/Shopify/marketing_assets/blob/master/app/assets/javascripts/marketing_assets/modules/accordion.js
